### PR TITLE
[NEGO-4145] Disable class name cop

### DIFF
--- a/default.yml
+++ b/default.yml
@@ -26,6 +26,9 @@ Metrics/LineLength:
 Airbnb/RspecDescribeOrContextUnderNamespace:
   Enabled: false
 
+Airbnb/ClassName:
+  Enabled: false
+
 Airbnb/ContinuationSlash:
   Enabled: false
 


### PR DESCRIPTION
AirBnb makes an argument that `"User"` is preferable to `User.name`, due to potentially long autoloading chains.

_However_, I feel that the opposite should be encouraged, for several reasons:
- During a refactor, `"User"` could easily get lost, resulting in broken data chains, where `User.name` will raise syntax errors
- Their argument is based on `belongs_to :user, class_name: "User"`, which is a bad example, and in practice, we don't use this in enough places to be substantially at risk for a long loading chain
- We _actively_ made the decision (pre-Rubocop) to do it the `.name` way for the first reason