### PR TITLE
[NEGO-5320] Turn equals sign alignment on

### DIFF
--- a/default.yml
+++ b/default.yml
@@ -125,6 +125,9 @@ Style/FormatString:
 Layout/AlignParameters:
   EnforcedStyle: with_fixed_indentation
 
+Layout/ExtraSpacing:
+  ForceEqualSignAlignment: true
+
 Layout/MultilineOperationIndentation:
   EnforcedStyle: indented
 


### PR DESCRIPTION
Ticket: [NEGO-5320](https://negotiatus.atlassian.net/browse/NEGO-5320)

Some people are using/enforcing equals sign alignment, but it is not actually part of our Rubocop custom rules.

Added according to https://rubocop.readthedocs.io/en/latest/cops_layout/#configurable-attributes_16