### PR TITLE
Adam rubocop defaults

### DIFF
--- a/default.yml
+++ b/default.yml
@@ -1,13 +1,10 @@
-inherit_from:
-  - .rubocop_airbnb.yml
-
 AllCops:
   Exclude:
-    - 'db/**/*'
-    - 'config/**/*'
-    - 'tmp/**/*'
-    - 'ssl_certificates/**/*'
-    - 'bin/**/*'
+    - "db/**/*"
+    - "config/**/*"
+    - "tmp/**/*"
+    - "ssl_certificates/**/*"
+    - "bin/**/*"
   TargetRubyVersion: 2.6
 
 Metrics/BlockLength:
@@ -22,7 +19,7 @@ Metrics/LineLength:
     - spec/*
     - spec/**
     - spec/**/**
-  Max: 150
+  Max: 100
 
 Airbnb/RspecDescribeOrContextUnderNamespace:
   Enabled: false
@@ -32,135 +29,3 @@ Airbnb/ContinuationSlash:
 
 Airbnb/RspecEnvironmentModification:
   Enabled: false
-
-Style/EmptyCaseCondition:
-  Enabled: false
-
-Style/FrozenStringLiteralComment:
-  Enabled: false
-
-Layout/AlignHash:
-  EnforcedColonStyle: table
-
-Layout/IndentFirstHashElement:
-  EnforcedStyle: consistent
-
-Layout/EmptyLineAfterGuardClause:
-  Enabled: true
-
-Style/TrailingCommaInArrayLiteral:
-  Enabled: false
-
-Style/TrailingCommaInHashLiteral:
-  Enabled: false
-
-Layout/SpaceInsideHashLiteralBraces:
-  EnforcedStyle: no_space
-
-Style/WordArray:
-  Enabled: false
-
-Style/SymbolArray:
-  Enabled: false
-
-Metrics/BlockNesting:
-  Max: 3
-
-Lint/AmbiguousOperator:
-  Enabled: false
-
-Lint/AmbiguousRegexpLiteral:
-  Enabled: false
-
-Lint/ParenthesesAsGroupedExpression:
-  Enabled: false
-
-Lint/UnusedBlockArgument:
-  Enabled: false
-
-Layout/EndAlignment:
-  EnforcedStyleAlignWith: keyword
-
-Lint/UnusedMethodArgument:
-  Enabled: false
-
-Style/SingleLineBlockParams:
-  Enabled: false
-
-Style/StringLiteralsInInterpolation:
-  Enabled: false
-
-Style/AndOr:
-  Enabled: false
-
-Style/SignalException:
-  Enabled: false
-
-Style/StringLiterals:
-  Enabled: false
-
-Style/BracesAroundHashParameters:
-  Enabled: false
-
-Style/NumericLiterals:
-  Enabled: false
-
-Layout/SpaceBeforeBlockBraces:
-  Enabled: true
-
-Layout/SpaceInsideBlockBraces:
-  Enabled: true
-
-Style/Documentation:
-  Enabled: false
-
-Style/ClassAndModuleChildren:
-  Enabled: false
-
-Style/FormatString:
-  Enabled: false
-
-Layout/AlignParameters:
-  EnforcedStyle: with_fixed_indentation
-
-Layout/ExtraSpacing:
-  ForceEqualSignAlignment: true
-
-Layout/MultilineOperationIndentation:
-  EnforcedStyle: indented
-
-Layout/DotPosition:
-  EnforcedStyle: leading
-
-Style/IfUnlessModifier:
-  Enabled: false
-
-Style/RaiseArgs:
-  Enabled: false
-
-Style/PreferredHashMethods:
-  Enabled: false
-
-Style/RegexpLiteral:
-  Enabled: false
-
-Style/SymbolLiteral:
-  Enabled: false
-
-Performance/Count:
-  Enabled: false
-
-Naming/ConstantName:
-  Enabled: false
-
-Layout/CaseIndentation:
-  Enabled: false
-
-Style/ClassVars:
-  Enabled: false
-
-Style/PerlBackrefs:
-  Enabled: false
-
-Style/TrivialAccessors:
-  AllowPredicates: true

--- a/lib/rubocop_rulez/style/version.rb
+++ b/lib/rubocop_rulez/style/version.rb
@@ -1,5 +1,5 @@
 module RubocopRulez
   module Style
-    VERSION = '1.0.0'.freeze
+    VERSION = '2.0.0'.freeze
   end
 end


### PR DESCRIPTION
Sets rules to Rubocop defaults while still keeping additional Airbnb cops.

If one or more of the Style rules that were removed are near and dear to your heart feel free to make a case and we can add it back in. 

Testing:

Still testing locally, will update when complete